### PR TITLE
Fix tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,10 +6,12 @@ on:
   workflow_dispatch:
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot' || github.actor == 'beacon-buddy'
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'beacon-buddy'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.BEACONBUDDY_SSH_KEY }}
+          registry: beacon-biosignals/BeaconRegistry
+          registry_ssh: ${{ secrets.BEACON_REGISTRY_RO_SSH_KEY }}


### PR DESCRIPTION
for real this time.

Note: BeaconK8sUtilities is open source, but only registered in BeaconRegistry (since it's not generally useful yet).